### PR TITLE
Table designs and add cell texts to have paragraph structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,9 +28,9 @@
 			"integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww=="
 		},
 		"node_modules/airppt-models-plus": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/airppt-models-plus/-/airppt-models-plus-1.0.2.tgz",
-			"integrity": "sha512-gSRTw2fNEzv2yJu9UrI/iEyitS79TIZcQfsomklOvSnUWg8DvdXNI8MeHMRM7qS12ZxuwTvCl4JH/DRIqULc/g==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/airppt-models-plus/-/airppt-models-plus-1.0.4.tgz",
+			"integrity": "sha512-pBRjTl6D2dIX4cb0OwQjLmsk4QQTdVlFCd3GtV+dm/3cHQcvllLv8Yg4e5oa8+XTZuAXNvXYSfOHBsfoqdpPOw==",
 			"dependencies": {
 				"@types/node": "^10.12.9",
 				"jszip": "^3.1.5",
@@ -481,9 +481,9 @@
 			"integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww=="
 		},
 		"airppt-models-plus": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/airppt-models-plus/-/airppt-models-plus-1.0.2.tgz",
-			"integrity": "sha512-gSRTw2fNEzv2yJu9UrI/iEyitS79TIZcQfsomklOvSnUWg8DvdXNI8MeHMRM7qS12ZxuwTvCl4JH/DRIqULc/g==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/airppt-models-plus/-/airppt-models-plus-1.0.4.tgz",
+			"integrity": "sha512-pBRjTl6D2dIX4cb0OwQjLmsk4QQTdVlFCd3GtV+dm/3cHQcvllLv8Yg4e5oa8+XTZuAXNvXYSfOHBsfoqdpPOw==",
 			"requires": {
 				"@types/node": "^10.12.9",
 				"jszip": "^3.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.3",
+	"version": "1.0.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.0.3",
+			"version": "1.0.5",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",
@@ -28,19 +28,14 @@
 			"integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww=="
 		},
 		"node_modules/airppt-models-plus": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/airppt-models-plus/-/airppt-models-plus-1.0.4.tgz",
-			"integrity": "sha512-pBRjTl6D2dIX4cb0OwQjLmsk4QQTdVlFCd3GtV+dm/3cHQcvllLv8Yg4e5oa8+XTZuAXNvXYSfOHBsfoqdpPOw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/airppt-models-plus/-/airppt-models-plus-1.0.5.tgz",
+			"integrity": "sha512-Ea4yIBradDykhUH/ej05NDiuly5Abu+lFkVgaJl15N+rhlVFdOXQ63L/UopgjQabTg2NhHR9frTR8XmgcCpPog==",
 			"dependencies": {
-				"@types/node": "^10.12.9",
+				"@types/node": "^15.12.2",
 				"jszip": "^3.1.5",
 				"xml2js-es6-promise": "^1.1.1"
 			}
-		},
-		"node_modules/airppt-models-plus/node_modules/@types/node": {
-			"version": "10.17.60",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-			"integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
 		},
 		"node_modules/assertion-error": {
 			"version": "1.1.0",
@@ -481,20 +476,13 @@
 			"integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww=="
 		},
 		"airppt-models-plus": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/airppt-models-plus/-/airppt-models-plus-1.0.4.tgz",
-			"integrity": "sha512-pBRjTl6D2dIX4cb0OwQjLmsk4QQTdVlFCd3GtV+dm/3cHQcvllLv8Yg4e5oa8+XTZuAXNvXYSfOHBsfoqdpPOw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/airppt-models-plus/-/airppt-models-plus-1.0.5.tgz",
+			"integrity": "sha512-Ea4yIBradDykhUH/ej05NDiuly5Abu+lFkVgaJl15N+rhlVFdOXQ63L/UopgjQabTg2NhHR9frTR8XmgcCpPog==",
 			"requires": {
-				"@types/node": "^10.12.9",
+				"@types/node": "^15.12.2",
 				"jszip": "^3.1.5",
 				"xml2js-es6-promise": "^1.1.1"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "10.17.60",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-					"integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-				}
 			}
 		},
 		"assertion-error": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/ts/helpers/checkobj.ts
+++ b/ts/helpers/checkobj.ts
@@ -14,9 +14,7 @@ export function getValueAtPath(obj: any, path: string): any {
 }
 
 export function checkPath(obj: any, path: string): boolean {
-    if (getValueAtPath(obj, path) === undefined) {
-        return false;
-    } else {
-        return true;
+    return getValueAtPath(obj, path) !== undefined;
+
     }
 }

--- a/ts/helpers/checkobj.ts
+++ b/ts/helpers/checkobj.ts
@@ -15,6 +15,4 @@ export function getValueAtPath(obj: any, path: string): any {
 
 export function checkPath(obj: any, path: string): boolean {
     return getValueAtPath(obj, path) !== undefined;
-
-    }
 }

--- a/ts/helpers/checkobj.ts
+++ b/ts/helpers/checkobj.ts
@@ -5,10 +5,18 @@
 
 import * as format from "string-template";
 
-export function CheckValidObject(obj: any, path: string): any {
+export function getValueAtPath(obj: any, path: string): any {
     try {
         return eval(format("obj{0}", path));
     } catch (e) {
         return undefined;
+    }
+}
+
+export function checkPath(obj: any, path: string): boolean {
+    if (getValueAtPath(obj, path) === undefined) {
+        return false;
+    } else {
+        return true;
     }
 }

--- a/ts/helpers/index.ts
+++ b/ts/helpers/index.ts
@@ -1,5 +1,4 @@
 import { getAttributeByPath } from "./attributesHandler";
-import { CheckValidObject as checkPath } from "./checkobj";
+import { getValueAtPath, checkPath } from "./checkobj";
 import ZipHandler from "./ziphandler";
-
-export { getAttributeByPath, checkPath, ZipHandler };
+export { getAttributeByPath, checkPath, getValueAtPath, ZipHandler };

--- a/ts/helpers/index.ts
+++ b/ts/helpers/index.ts
@@ -1,0 +1,5 @@
+import { getAttributeByPath } from "./attributesHandler";
+import { CheckValidObject as checkPath } from "./checkobj";
+import ZipHandler from "./ziphandler";
+
+export { getAttributeByPath, checkPath, ZipHandler };

--- a/ts/main.ts
+++ b/ts/main.ts
@@ -13,7 +13,7 @@ export class AirParser {
             const slidesLength = await PptGlobalsParser.getSlidesLength(this.PowerpointFilePath);
             const allSlides = [];
 
-            for (let i = 1; i <= slidesLength + 1; i++) {
+            for (let i = 1; i <= slidesLength; i++) {
                 allSlides.push(SlideParser.getSlideElements(pptElementParser, i));
             }
 

--- a/ts/main.ts
+++ b/ts/main.ts
@@ -1,8 +1,6 @@
 //require("module-alias/register");
 import { PowerpointDetails } from "airppt-models-plus/pptdetails";
-import PowerpointElementParser from "./parsers/elementparser";
-import PptGlobalsParser from "./parsers/pptGlobalsParser";
-import SlideParser from "./parsers/slideParser";
+import { PowerpointElementParser, PptGlobalsParser, SlideParser } from "./parsers";
 
 export class AirParser {
     constructor(private readonly PowerpointFilePath: string) {}
@@ -17,23 +15,21 @@ export class AirParser {
                 allSlides.push(SlideParser.getSlideElements(pptElementParser, i));
             }
 
-            Promise.allSettled(allSlides)
-                .then((result) => {
-                    const pptElements = result.map((slideElements) => {
-                        if (slideElements.status === "fulfilled") {
-                            return slideElements.value;
-                        }
+            Promise.allSettled(allSlides).then((result) => {
+                const pptElements = result.map((slideElements) => {
+                    if (slideElements.status === "fulfilled") {
+                        return slideElements.value;
+                    }
 
-                        return [];
-                    });
+                    return [];
+                });
 
-                    resolve({
-                        powerPointElements: pptElements,
-                        inputPath: this.PowerpointFilePath,
-                        slidesLength
-                    });
-                })
-            ;
+                resolve({
+                    powerPointElements: pptElements,
+                    inputPath: this.PowerpointFilePath,
+                    slidesLength
+                });
+            });
         });
     }
 }

--- a/ts/parsers/colorparser.ts
+++ b/ts/parsers/colorparser.ts
@@ -1,4 +1,4 @@
-import { checkPath } from "../helpers";
+import { checkPath, getValueAtPath } from "../helpers";
 import { SlideRelationsParser } from "./";
 import { PowerpointElement, FillType } from "airppt-models-plus/pptelement";
 import * as isEmpty from "lodash.isempty";
@@ -44,8 +44,8 @@ export default class ColorParser {
         if (shapeProperties["a:solidFill"]) {
             //determine if it is theme or solid fill
             const solidColor =
-                checkPath(shapeProperties, '["a:solidFill"]["0"]["a:srgbClr"]["0"]["$"]["val"]') ||
-                // this.getThemeColor(checkPath(shapeProperties, '["a:solidFill"]["0"]["a:schemeClr"]["0"]["$"]["val"]')) ||
+                getValueAtPath(shapeProperties, '["a:solidFill"]["0"]["a:srgbClr"]["0"]["$"]["val"]') ||
+                // this.getThemeColor(getValueAtPath(shapeProperties, '["a:solidFill"]["0"]["a:schemeClr"]["0"]["$"]["val"]')) ||
                 "FFFFFF";
 
             fillType.fillColor = solidColor;
@@ -53,8 +53,8 @@ export default class ColorParser {
         }
 
         //look at p:style for shape default theme values
-        // const shapeStyle = checkPath(element, '["p:style"][0]');
-        // fillType.fillColor = this.getThemeColor(checkPath(shapeStyle, '["a:fillRef"]["0"]["a:schemeClr"]["0"]["$"]["val"]')) || "FFFFFF";
+        // const shapeStyle = getValueAtPath(element, '["p:style"][0]');
+        // fillType.fillColor = this.getThemeColor(getValueAtPath(shapeStyle, '["a:fillRef"]["0"]["a:schemeClr"]["0"]["$"]["val"]')) || "FFFFFF";
         fillType.fillColor = "FFFFFF";
 
         return fillType;
@@ -69,11 +69,11 @@ export default class ColorParser {
         const shapeProperties = element["p:spPr"][0];
         if (shapeProperties["a:solidFill"]) {
             //determine if it is theme or solid fill
-            if (checkPath(shapeProperties, '["a:solidFill"]["0"]["a:srgbClr"]["0"]["a:alpha"][0]["$"]["val"]') != undefined) {
+            if (checkPath(shapeProperties, '["a:solidFill"]["0"]["a:srgbClr"]["0"]["a:alpha"][0]["$"]["val"]')) {
                 return shapeProperties["a:solidFill"]["0"]["a:srgbClr"]["0"]["a:alpha"][0]["$"]["val"];
             }
 
-            if (checkPath(shapeProperties, '["a:solidFill"]["0"]["a:schemeClr"]["0"]["a:alpha"][0]["$"]["val"]') != undefined) {
+            if (checkPath(shapeProperties, '["a:solidFill"]["0"]["a:schemeClr"]["0"]["a:alpha"][0]["$"]["val"]')) {
                 return shapeProperties["a:solidFill"]["0"]["a:schemeClr"]["0"]["a:alpha"][0]["$"]["val"];
             }
         }
@@ -89,7 +89,7 @@ export default class ColorParser {
     public static getTextColors(textElement): string {
         if ("a:solidFill" in textElement) {
             return (
-                checkPath(textElement, '["a:solidFill"]["0"]["a:srgbClr"]["0"]["$"]["val"]') ||
+                getValueAtPath(textElement, '["a:solidFill"]["0"]["a:srgbClr"]["0"]["$"]["val"]') ||
                 //commenting this as text colors are not required in our case
                 // this.getThemeColor(checkPath(textElement, '["a:solidFill"]["0"]["a:schemeClr"]["0"]["$"]["val"]')) ||
                 "000000"

--- a/ts/parsers/colorparser.ts
+++ b/ts/parsers/colorparser.ts
@@ -1,5 +1,5 @@
-import { CheckValidObject as checkPath } from "../helpers/checkobj";
-import RelationParser from "./relparser";
+import { checkPath } from "../helpers";
+import { SlideRelationsParser } from "./";
 import { PowerpointElement, FillType } from "airppt-models-plus/pptelement";
 import * as isEmpty from "lodash.isempty";
 /**
@@ -37,7 +37,7 @@ export default class ColorParser {
         if (shapeProperties["a:blipFill"]) {
             const relId = shapeProperties["a:blipFill"][0]["a:blip"][0]["$"]["r:embed"];
             fillType.fillType = FillType.Image;
-            fillType.fillColor = RelationParser.getRelationDetails(relId).Uri || "NONE";
+            fillType.fillColor = SlideRelationsParser.getRelationDetails(relId).Uri || "NONE";
             return fillType;
         }
 

--- a/ts/parsers/elementparser.ts
+++ b/ts/parsers/elementparser.ts
@@ -1,9 +1,11 @@
 import { CheckValidObject } from "../helpers/checkobj";
-import ShapeParser from "./shapeparser";
-import ParagraphParser from "./paragraphparser";
-import SlideRelationsParser from "./relparser";
 import { PowerpointElement } from "airppt-models-plus/pptelement";
-import GraphicFrameParser from "./graphicFrameParser";
+import {
+    GraphicFrameParser,
+    ShapeParser,
+    SlideRelationsParser,
+    ParagraphParser
+} from "./";
 import { cleanupJson } from "../utils/common";
 import * as isEmpty from "lodash.isempty";
 

--- a/ts/parsers/elementparser.ts
+++ b/ts/parsers/elementparser.ts
@@ -1,4 +1,4 @@
-import { checkPath } from "../helpers";
+import { checkPath, getValueAtPath } from "../helpers";
 import { PowerpointElement } from "airppt-models-plus/pptelement";
 import {
     GraphicFrameParser,
@@ -34,7 +34,7 @@ class PowerpointElementParser {
                     this.element["p:nvSpPr"][0]["p:cNvPr"][0]["$"]["title"] ||
                     this.element["p:nvSpPr"][0]["p:cNvPr"][0]["$"]["name"].replace(/\s/g, "");
 
-                if (checkPath(this.element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') === "ctrTitle") {
+                if (getValueAtPath(this.element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') === "ctrTitle") {
                     isTitle = true;
                 }
 
@@ -75,9 +75,9 @@ class PowerpointElementParser {
                 table = GraphicFrameParser.extractTableElements(this.element);
             }
 
-            const elementPresetType = checkPath(this.element, '["p:spPr"][0]["a:prstGeom"][0]["$"]["prst"]') || "none";
+            const elementPresetType = getValueAtPath(this.element, '["p:spPr"][0]["a:prstGeom"][0]["$"]["prst"]') || "none";
 
-            const paragraphInfo = checkPath(this.element, '["p:txBody"][0]["a:p"]');
+            const paragraphInfo = getValueAtPath(this.element, '["p:txBody"][0]["a:p"]');
 
             let pptElement: PowerpointElement = {
                 name: elementName,

--- a/ts/parsers/elementparser.ts
+++ b/ts/parsers/elementparser.ts
@@ -1,4 +1,4 @@
-import { CheckValidObject } from "../helpers/checkobj";
+import { checkPath } from "../helpers";
 import { PowerpointElement } from "airppt-models-plus/pptelement";
 import {
     GraphicFrameParser,
@@ -34,7 +34,7 @@ class PowerpointElementParser {
                     this.element["p:nvSpPr"][0]["p:cNvPr"][0]["$"]["title"] ||
                     this.element["p:nvSpPr"][0]["p:cNvPr"][0]["$"]["name"].replace(/\s/g, "");
 
-                if (CheckValidObject(this.element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') === "ctrTitle") {
+                if (checkPath(this.element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') === "ctrTitle") {
                     isTitle = true;
                 }
 
@@ -61,7 +61,7 @@ class PowerpointElementParser {
             }
             //check only if its the table, in future can be changed it to overall graphic types e.g. diagrams, charts.
             //but for now only doing the tables.
-            else if (CheckValidObject(this.element, '["a:graphic"][0]["a:graphicData"][0]["a:tbl"]')) {
+            else if (checkPath(this.element, '["a:graphic"][0]["a:graphicData"][0]["a:tbl"]')) {
                 elementName =
                     this.element["p:nvGraphicFramePr"][0]["p:cNvPr"][0]["$"]["title"] ||
                     this.element["p:nvGraphicFramePr"][0]["p:cNvPr"][0]["$"]["name"].replace(/\s/g, "");
@@ -75,9 +75,9 @@ class PowerpointElementParser {
                 table = GraphicFrameParser.extractTableElements(this.element);
             }
 
-            const elementPresetType = CheckValidObject(this.element, '["p:spPr"][0]["a:prstGeom"][0]["$"]["prst"]') || "none";
+            const elementPresetType = checkPath(this.element, '["p:spPr"][0]["a:prstGeom"][0]["$"]["prst"]') || "none";
 
-            const paragraphInfo = CheckValidObject(this.element, '["p:txBody"][0]["a:p"]');
+            const paragraphInfo = checkPath(this.element, '["p:txBody"][0]["a:p"]');
 
             let pptElement: PowerpointElement = {
                 name: elementName,

--- a/ts/parsers/graphicFrameParser.ts
+++ b/ts/parsers/graphicFrameParser.ts
@@ -2,7 +2,7 @@
 
 import { getAttributeByPath } from "../helpers/attributesHandler";
 import * as isEmpty from "lodash.isempty";
-import { Paragraph, PowerpointElement, TableDesign } from "airppt-models-plus/pptelement";
+import { TableDesign } from "airppt-models-plus/pptelement";
 import { CheckValidObject } from "../helpers/checkobj";
 import ParagraphParser from "./paragraphparser";
 

--- a/ts/parsers/graphicFrameParser.ts
+++ b/ts/parsers/graphicFrameParser.ts
@@ -1,6 +1,6 @@
 //Graphic frame node includes tables, charts and diagrams
 
-import { getAttributeByPath, checkPath } from "../helpers";
+import { getAttributeByPath, getValueAtPath } from "../helpers";
 import * as isEmpty from "lodash.isempty";
 import { TableDesign } from "airppt-models-plus/pptelement";
 import { ParagraphParser } from "./";
@@ -68,7 +68,7 @@ export default class GraphicFrameParser {
                     }
                 }
 
-                const paragraphInfo = checkPath(col, '["a:txBody"][0]["a:p"]');
+                const paragraphInfo = getValueAtPath(col, '["a:txBody"][0]["a:p"]');
                 let parsedParagraph = ParagraphParser.extractParagraphElements(paragraphInfo);
                 //edge case to handle the empty cell, without this check it will be sent as { paragraph: { content: [], ....}}
                 //and that is considered as line break in our renderer

--- a/ts/parsers/graphicFrameParser.ts
+++ b/ts/parsers/graphicFrameParser.ts
@@ -2,7 +2,9 @@
 
 import { getAttributeByPath } from "../helpers/attributesHandler";
 import * as isEmpty from "lodash.isempty";
-import { TableDesign } from "airppt-models-plus/pptelement";
+import { Paragraph, PowerpointElement, TableDesign } from "airppt-models-plus/pptelement";
+import { CheckValidObject } from "../helpers/checkobj";
+import ParagraphParser from "./paragraphparser";
 
 export default class GraphicFrameParser {
     public static processGraphicFrameNodes = (graphicFrames) => {
@@ -38,12 +40,13 @@ export default class GraphicFrameParser {
         }
 
         return tableDesigns;
-    }
+    };
 
     public static extractTableElements = (frame) => {
         const rawTable = getAttributeByPath([frame], ["a:graphic", "a:graphicData", "a:tbl"]);
         const rawRows = rawTable[0]["a:tr"] ? rawTable[0]["a:tr"] : [];
 
+        //TODO: column width mapping to be done here using rawTable[a:tblGrid]
         const tableRows = rawRows.map((row) => {
             let cols = row["a:tc"] ? row["a:tc"] : [];
             cols = cols.filter((col) => {
@@ -66,12 +69,16 @@ export default class GraphicFrameParser {
                     }
                 }
 
-                //TODO: check if the text can have multiple values in an array, by default have seen only one so far
-                // hence getting 0th index
-                const textContent = getAttributeByPath([col], ["a:txBody", "a:p", "a:r", "a:t"])[0] || "";
+                const paragraphInfo = CheckValidObject(col, '["a:txBody"][0]["a:p"]');
+                let parsedParagraph = ParagraphParser.extractParagraphElements(paragraphInfo);
+                //edge case to handle the empty cell, without this check it will be sent as { paragraph: { content: [], ....}}
+                //and that is considered as line break in our renderer
+                if (parsedParagraph.length === 1 && isEmpty(parsedParagraph[0].content)) {
+                    parsedParagraph = [];
+                }
+
                 return {
-                    //raw data doesn't have a property of text if the cell is empty, therefore we return an empty string
-                    text: typeof textContent === "string" ? textContent : "",
+                    paragraph: parsedParagraph,
                     meta
                 };
             });
@@ -81,7 +88,6 @@ export default class GraphicFrameParser {
             };
         });
 
-        //TODO: return any other possible and helpful table info
         return {
             tableDesign: GraphicFrameParser.getTableDesigns(rawTable),
             rows: tableRows

--- a/ts/parsers/graphicFrameParser.ts
+++ b/ts/parsers/graphicFrameParser.ts
@@ -1,6 +1,8 @@
 //Graphic frame node includes tables, charts and diagrams
 
 import { getAttributeByPath } from "../helpers/attributesHandler";
+import * as isEmpty from "lodash.isempty";
+import { TableDesign } from "airppt-models-plus/pptelement";
 
 export default class GraphicFrameParser {
     public static processGraphicFrameNodes = (graphicFrames) => {
@@ -23,6 +25,20 @@ export default class GraphicFrameParser {
 
         return result;
     };
+
+    static getTableDesigns = (table: any[]): string[] => {
+        const allDesigns = getAttributeByPath(table, ["a:tblPr", "$"]);
+        const tableDesigns = [];
+        if (!isEmpty(allDesigns)) {
+            for (const supportedDesign of Object.values(TableDesign)) {
+                if (allDesigns[supportedDesign]) {
+                    tableDesigns.push(supportedDesign);
+                }
+            }
+        }
+
+        return tableDesigns;
+    }
 
     public static extractTableElements = (frame) => {
         const rawTable = getAttributeByPath([frame], ["a:graphic", "a:graphicData", "a:tbl"]);
@@ -67,6 +83,7 @@ export default class GraphicFrameParser {
 
         //TODO: return any other possible and helpful table info
         return {
+            tableDesign: GraphicFrameParser.getTableDesigns(rawTable),
             rows: tableRows
         };
     };

--- a/ts/parsers/graphicFrameParser.ts
+++ b/ts/parsers/graphicFrameParser.ts
@@ -1,10 +1,9 @@
 //Graphic frame node includes tables, charts and diagrams
 
-import { getAttributeByPath } from "../helpers/attributesHandler";
+import { getAttributeByPath, checkPath } from "../helpers";
 import * as isEmpty from "lodash.isempty";
 import { TableDesign } from "airppt-models-plus/pptelement";
-import { CheckValidObject } from "../helpers/checkobj";
-import ParagraphParser from "./paragraphparser";
+import { ParagraphParser } from "./";
 
 export default class GraphicFrameParser {
     public static processGraphicFrameNodes = (graphicFrames) => {
@@ -69,7 +68,7 @@ export default class GraphicFrameParser {
                     }
                 }
 
-                const paragraphInfo = CheckValidObject(col, '["a:txBody"][0]["a:p"]');
+                const paragraphInfo = checkPath(col, '["a:txBody"][0]["a:p"]');
                 let parsedParagraph = ParagraphParser.extractParagraphElements(paragraphInfo);
                 //edge case to handle the empty cell, without this check it will be sent as { paragraph: { content: [], ....}}
                 //and that is considered as line break in our renderer

--- a/ts/parsers/index.ts
+++ b/ts/parsers/index.ts
@@ -1,0 +1,21 @@
+import ColorParser from "./colorparser";
+import PowerpointElementParser from "./elementparser";
+import GraphicFrameParser from "./graphicFrameParser";
+import PptGlobalsParser from "./pptGlobalsParser";
+import LineParser from "./lineparser";
+import ParagraphParser from "./paragraphparser";
+import SlideParser from "./slideParser";
+import SlideRelationsParser from "./relparser";
+import ShapeParser from "./shapeparser";
+
+export {
+    ColorParser,
+    PowerpointElementParser,
+    GraphicFrameParser,
+    PptGlobalsParser,
+    LineParser,
+    ParagraphParser,
+    SlideParser,
+    SlideRelationsParser,
+    ShapeParser
+};

--- a/ts/parsers/lineparser.ts
+++ b/ts/parsers/lineparser.ts
@@ -1,6 +1,4 @@
 import { CheckValidObject as checkPath } from "../helpers/checkobj";
-import ColorParser from "./colorparser";
-
 import { PowerpointElement, BorderType } from "airppt-models-plus/pptelement";
 
 /**

--- a/ts/parsers/lineparser.ts
+++ b/ts/parsers/lineparser.ts
@@ -1,4 +1,4 @@
-import { checkPath } from "../helpers";
+import { getValueAtPath } from "../helpers";
 import { PowerpointElement, BorderType } from "airppt-models-plus/pptelement";
 
 /**
@@ -30,7 +30,7 @@ export default class LineParser {
             return null;
         }
 
-        let dashType = checkPath(lineProperties, '["a:prstDash"][0]["$"]["val"]') || "default";
+        let dashType = getValueAtPath(lineProperties, '["a:prstDash"][0]["$"]["val"]') || "default";
         switch (dashType) {
             case "solid":
                 return BorderType.solid;
@@ -50,7 +50,7 @@ export default class LineParser {
             return null;
         }
 
-        return checkPath(lineProperties, '["$"]["w"]') || 1000;
+        return getValueAtPath(lineProperties, '["$"]["w"]') || 1000;
     }
     public static getLineColor(shapeProperties) {
         let lineProperties = shapeProperties["a:ln"][0];
@@ -61,8 +61,8 @@ export default class LineParser {
         }
 
         return (
-            checkPath(lineProperties, '["a:solidFill"]["0"]["a:srgbClr"]["0"]["$"]["val"]') ||
-            // ColorParser.getThemeColor(checkPath(lineProperties, '["a:solidFill"]["0"]["a:schemeClr"]["0"]["$"]["val"]')) ||
+            getValueAtPath(lineProperties, '["a:solidFill"]["0"]["a:srgbClr"]["0"]["$"]["val"]') ||
+            // ColorParser.getThemeColor(getValueAtPath(lineProperties, '["a:solidFill"]["0"]["a:schemeClr"]["0"]["$"]["val"]')) ||
             "000000"
         );
     }

--- a/ts/parsers/lineparser.ts
+++ b/ts/parsers/lineparser.ts
@@ -1,4 +1,4 @@
-import { CheckValidObject as checkPath } from "../helpers/checkobj";
+import { checkPath } from "../helpers";
 import { PowerpointElement, BorderType } from "airppt-models-plus/pptelement";
 
 /**

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -1,4 +1,4 @@
-import { checkPath } from "../helpers";
+import { getValueAtPath } from "../helpers";
 import { ColorParser } from "./";
 
 import {
@@ -23,7 +23,7 @@ export default class ParagraphParser {
             const content = textElements.map((txtElement) => {
                 return {
                     text: txtElement["a:t"] || "",
-                    textCharacterProperties: this.determineTextProperties(checkPath(txtElement, '["a:rPr"][0]'))
+                    textCharacterProperties: this.determineTextProperties(getValueAtPath(txtElement, '["a:rPr"][0]'))
                 };
             });
 
@@ -41,9 +41,9 @@ export default class ParagraphParser {
         }
 
         const textPropertiesElement: Content["textCharacterProperties"] = {
-            size: checkPath(textProperties, '["$"].sz') || 1200,
+            size: getValueAtPath(textProperties, '["$"].sz') || 1200,
             fontAttributes: this.determineFontAttributes(textProperties["$"]),
-            font: checkPath(textProperties, '["a:latin"][0]["$"]["typeface"]') || "Helvetica",
+            font: getValueAtPath(textProperties, '["a:latin"][0]["$"]["typeface"]') || "Helvetica",
             fillColor: ColorParser.getTextColors(textProperties) || "000000"
         };
 
@@ -81,7 +81,7 @@ export default class ParagraphParser {
 
         let alignment: TextAlignment = TextAlignment.Left;
 
-        const alignProps = checkPath(paragraphProperties, '["a:pPr"][0]["$"]["algn"]');
+        const alignProps = getValueAtPath(paragraphProperties, '["a:pPr"][0]["$"]["algn"]');
 
         if (alignProps) {
             switch (alignProps) {

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -1,7 +1,7 @@
 import { CheckValidObject } from "../helpers/checkobj";
 import ColorParser from "./colorparser";
 
-import { 
+import {
     PowerpointElement,
     TextAlignment,
     FontAttributes,

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -1,5 +1,5 @@
-import { CheckValidObject } from "../helpers/checkobj";
-import ColorParser from "./colorparser";
+import { checkPath } from "../helpers";
+import { ColorParser } from "./";
 
 import {
     PowerpointElement,
@@ -23,7 +23,7 @@ export default class ParagraphParser {
             const content = textElements.map((txtElement) => {
                 return {
                     text: txtElement["a:t"] || "",
-                    textCharacterProperties: this.determineTextProperties(CheckValidObject(txtElement, '["a:rPr"][0]'))
+                    textCharacterProperties: this.determineTextProperties(checkPath(txtElement, '["a:rPr"][0]'))
                 };
             });
 
@@ -41,9 +41,9 @@ export default class ParagraphParser {
         }
 
         const textPropertiesElement: Content["textCharacterProperties"] = {
-            size: CheckValidObject(textProperties, '["$"].sz') || 1200,
+            size: checkPath(textProperties, '["$"].sz') || 1200,
             fontAttributes: this.determineFontAttributes(textProperties["$"]),
-            font: CheckValidObject(textProperties, '["a:latin"][0]["$"]["typeface"]') || "Helvetica",
+            font: checkPath(textProperties, '["a:latin"][0]["$"]["typeface"]') || "Helvetica",
             fillColor: ColorParser.getTextColors(textProperties) || "000000"
         };
 
@@ -81,7 +81,7 @@ export default class ParagraphParser {
 
         let alignment: TextAlignment = TextAlignment.Left;
 
-        const alignProps = CheckValidObject(paragraphProperties, '["a:pPr"][0]["$"]["algn"]');
+        const alignProps = checkPath(paragraphProperties, '["a:pPr"][0]["$"]["algn"]');
 
         if (alignProps) {
             switch (alignProps) {

--- a/ts/parsers/pptGlobalsParser.ts
+++ b/ts/parsers/pptGlobalsParser.ts
@@ -1,6 +1,4 @@
-import { getAttributeByPath } from "../helpers/attributesHandler";
-import ZipHandler from "../helpers/ziphandler";
-
+import { getAttributeByPath, ZipHandler} from "../helpers";
 export default class PptGlobalsParser {
     public static async getSlidesLength(pptFilePath: string) {
         //@todo: PROBLEM - Implement error handling

--- a/ts/parsers/relparser.ts
+++ b/ts/parsers/relparser.ts
@@ -1,4 +1,4 @@
-import { checkPath } from "../helpers";
+import { getValueAtPath } from "../helpers";
 import { PowerpointElement, LinkType } from "airppt-models-plus/pptelement";
 
 /**
@@ -15,8 +15,8 @@ export default class SlideRelationsParser {
     }
 
     public static resolveShapeHyperlinks(element): PowerpointElement["links"] {
-        let relID = checkPath(element, '["p:nvSpPr"][0]["p:cNvPr"][0]["a:hlinkClick"][0]["$"]["r:id"]');
-        relID = checkPath(element, '["p:blipFill"][0]["a:blip"][0]["$"]["r:embed"]');
+        let relID = getValueAtPath(element, '["p:nvSpPr"][0]["p:cNvPr"][0]["a:hlinkClick"][0]["$"]["r:id"]');
+        relID = getValueAtPath(element, '["p:blipFill"][0]["a:blip"][0]["$"]["r:embed"]');
         if (!relID) {
             return null;
         }

--- a/ts/parsers/relparser.ts
+++ b/ts/parsers/relparser.ts
@@ -1,6 +1,4 @@
-import { CheckValidObject as checkPath, CheckValidObject } from "../helpers/checkobj";
-import { link } from "fs";
-
+import { CheckValidObject as checkPath } from "../helpers/checkobj";
 import { PowerpointElement, LinkType } from "airppt-models-plus/pptelement";
 
 /**
@@ -17,8 +15,8 @@ export default class SlideRelationsParser {
     }
 
     public static resolveShapeHyperlinks(element): PowerpointElement["links"] {
-        let relID = CheckValidObject(element, '["p:nvSpPr"][0]["p:cNvPr"][0]["a:hlinkClick"][0]["$"]["r:id"]');
-        relID = CheckValidObject(element, '["p:blipFill"][0]["a:blip"][0]["$"]["r:embed"]');
+        let relID = checkPath(element, '["p:nvSpPr"][0]["p:cNvPr"][0]["a:hlinkClick"][0]["$"]["r:id"]');
+        relID = checkPath(element, '["p:blipFill"][0]["a:blip"][0]["$"]["r:embed"]');
         if (!relID) {
             return null;
         }

--- a/ts/parsers/relparser.ts
+++ b/ts/parsers/relparser.ts
@@ -1,4 +1,4 @@
-import { CheckValidObject as checkPath } from "../helpers/checkobj";
+import { checkPath } from "../helpers";
 import { PowerpointElement, LinkType } from "airppt-models-plus/pptelement";
 
 /**

--- a/ts/parsers/shapeparser.ts
+++ b/ts/parsers/shapeparser.ts
@@ -1,4 +1,4 @@
-import { checkPath } from "../helpers";
+import { checkPath, getValueAtPath } from "../helpers";
 import { ColorParser, LineParser } from "./";
 import { PowerpointElement, SpecialityType } from "airppt-models-plus/pptelement";
 
@@ -19,7 +19,7 @@ export default class ShapeParser {
             return SpecialityType.Table;
         }
 
-        if (checkPath(element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') === "ctrTitle") {
+        if (getValueAtPath(element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') === "ctrTitle") {
             return SpecialityType.Title;
         }
 

--- a/ts/parsers/shapeparser.ts
+++ b/ts/parsers/shapeparser.ts
@@ -1,7 +1,5 @@
 import { CheckValidObject as checkPath } from "../helpers/checkobj";
-import ColorParser from "./colorparser";
-import LineParser from "./lineparser";
-
+import { ColorParser, LineParser } from "./";
 import { PowerpointElement, SpecialityType } from "airppt-models-plus/pptelement";
 
 /**

--- a/ts/parsers/shapeparser.ts
+++ b/ts/parsers/shapeparser.ts
@@ -1,4 +1,4 @@
-import { CheckValidObject as checkPath } from "../helpers/checkobj";
+import { checkPath } from "../helpers";
 import { ColorParser, LineParser } from "./";
 import { PowerpointElement, SpecialityType } from "airppt-models-plus/pptelement";
 

--- a/ts/parsers/slideParser.ts
+++ b/ts/parsers/slideParser.ts
@@ -1,6 +1,5 @@
 import * as format from "string-template";
-import ZipHandler from "../helpers/ziphandler";
-import { getAttributeByPath } from "../helpers/attributesHandler";
+import { getAttributeByPath, ZipHandler } from "../helpers";
 import { GraphicFrameParser, PowerpointElementParser } from "./";
 
 export default class SlideParser {

--- a/ts/parsers/slideParser.ts
+++ b/ts/parsers/slideParser.ts
@@ -1,8 +1,7 @@
 import * as format from "string-template";
 import ZipHandler from "../helpers/ziphandler";
 import { getAttributeByPath } from "../helpers/attributesHandler";
-import GraphicFrameParser from "../parsers/graphicFrameParser";
-import PowerpointElementParser from "../parsers/elementparser";
+import { GraphicFrameParser, PowerpointElementParser } from "./";
 
 export default class SlideParser {
     public static async getSlideElements(PPTElementParser: PowerpointElementParser, slideNumber): Promise<any[]> {


### PR DESCRIPTION
### This PR includes
 - #### Table Designs
   - Table headers -> If the table has the header or not, currently checking for row header only
   - Banded rows -> If table has the banded rows style applied
 
   _Note: these are the only designs supported by our tool so only having these, more designs can be handled later on, in order to support more designs, simply add the required design properties in the [airppt_models](https://github.com/rabi92/airppt-models)  at [this](https://github.com/rabi92/airppt-models/blob/dev/pptelement.ts#L50) file and they will be parsed into the resulting JSON automatically.
   For example: banded columns, column headers etc._ 
   
   Reference to add more styles and implementation: http://officeopenxml.com/drwTableStyles.php
   
 - #### Paragraphs structure
   - Previously we only had a `text` property within the cell, with this PR we have a full `paragraph` structure in, so we can have all sort of formatting, styles and alignments of the text like we have for the text boxes
   PR for paragraph parsing: https://github.com/rabi92/airppt-parser/pull/2
   
### Next TODO
 - Add table columns width and rows height
  _TODO with the comment can be found in this PR changes to help add it in the future._ 
  Refer to this link for help implementing it: http://officeopenxml.com/drwTableGrid.php
  
  Previous PR for Tables: https://github.com/rabi92/airppt-parser/pull/2