### PR TITLE
Get placeholder's information from the slide and master layouts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "prettier.printWidth": 120
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.20",
+	"version": "1.0.21",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "airppt-parser-plus",
-			"version": "1.0.20",
+			"version": "1.0.21",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.2",
+	"version": "1.1.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.1.2",
+			"version": "1.1.6",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "1.1.0",
+			"name": "airppt-parser-plus",
+			"version": "1.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.19",
+	"version": "1.0.20",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.0.19",
+			"version": "1.0.20",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.6",
+	"version": "1.1.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.1.6",
+			"version": "1.1.7",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.21",
+	"version": "1.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "1.0.21",
+			"version": "1.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.13",
+	"version": "1.0.17",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.0.13",
+			"version": "1.0.17",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.17",
+	"version": "1.0.19",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.0.17",
+			"version": "1.0.19",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.1.1",
+			"version": "1.1.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.13",
+	"version": "1.0.18",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.20",
+	"version": "1.0.21",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.19",
+	"version": "1.0.20",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.21",
+	"version": "1.1.0",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.2",
+	"version": "1.1.6",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.6",
+	"version": "1.1.7",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.0.18",
+	"version": "1.0.19",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/ts/helpers/attributesHandler.ts
+++ b/ts/helpers/attributesHandler.ts
@@ -9,8 +9,6 @@ export const getAttributeByPath = (slideAttributes, pathArray: string[], returnV
 
     for (const node of pathArray) {
         if (Array.isArray(slideAttributes)) {
-            //get the first index and that will be an object,
-            //so far haven't seen arrays of arrays in OOXML structure
             slideAttributes = slideAttributes[0];
         }
         slideAttributes = slideAttributes[node];

--- a/ts/helpers/attributesHandler.ts
+++ b/ts/helpers/attributesHandler.ts
@@ -9,7 +9,11 @@ export const getAttributeByPath = (slideAttributes, pathArray: string[]) => {
     }
 
     for (const node of pathArray) {
-        slideAttributes = slideAttributes[node] || slideAttributes[0][node];
+        if (Array.isArray(slideAttributes)) {
+            slideAttributes = slideAttributes[node] || slideAttributes[0][node];
+        } else {
+            slideAttributes = slideAttributes[node];
+        }
         if (slideAttributes === undefined) {
             return [];
         }

--- a/ts/helpers/attributesHandler.ts
+++ b/ts/helpers/attributesHandler.ts
@@ -9,10 +9,11 @@ export const getAttributeByPath = (slideAttributes, pathArray: string[], returnV
 
     for (const node of pathArray) {
         if (Array.isArray(slideAttributes)) {
-            slideAttributes = slideAttributes[node] || slideAttributes[0][node];
-        } else {
-            slideAttributes = slideAttributes[node];
+            //get the first index and that will be an object,
+            //so far haven't seen arrays of arrays in OOXML structure
+            slideAttributes = slideAttributes[0];
         }
+        slideAttributes = slideAttributes[node];
         if (slideAttributes === undefined) {
             return returnValue;
         }

--- a/ts/helpers/attributesHandler.ts
+++ b/ts/helpers/attributesHandler.ts
@@ -1,11 +1,10 @@
-export const getAttributeByPath = (slideAttributes, pathArray: string[]) => {
+export const getAttributeByPath = (slideAttributes, pathArray: string[], returnValue = undefined) => {
     if (pathArray.length === 0) {
-        //TODO: catch this error
-        throw Error("Invalid path");
+        return returnValue;
     }
 
     if (slideAttributes === undefined) {
-        return undefined;
+        return returnValue;
     }
 
     for (const node of pathArray) {
@@ -15,8 +14,12 @@ export const getAttributeByPath = (slideAttributes, pathArray: string[]) => {
             slideAttributes = slideAttributes[node];
         }
         if (slideAttributes === undefined) {
-            return [];
+            return returnValue;
         }
+    }
+
+    if (Array.isArray(returnValue)) {
+        return Array.isArray(slideAttributes) ? slideAttributes : [];
     }
 
     return slideAttributes;

--- a/ts/helpers/ziphandler.ts
+++ b/ts/helpers/ziphandler.ts
@@ -17,7 +17,10 @@ export default class ZipHandler {
 
     public static async parseSlideAttributes(fileName) {
         let presentationSlide = await this.zipResult.file(fileName).async("text");
-        let parsedPresentationSlide = await xml2js(presentationSlide, { trim: true, preserveChildrenOrderForMixedContent: true });
+        let parsedPresentationSlide = await xml2js(presentationSlide, {
+            trim: true,
+            preserveChildrenOrderForMixedContent: true
+        });
 
         return parsedPresentationSlide;
     }

--- a/ts/helpers/ziphandler.ts
+++ b/ts/helpers/ziphandler.ts
@@ -4,20 +4,19 @@ import fs = require("fs");
 import * as xml2js from "xml2js-es6-promise";
 
 export default class ZipHandler {
-    private static zip = new JSZip();
+    private static readonly zip = new JSZip();
     private static zipResult: JSZip;
 
-    public static loadZip(zipFilePath: string): Promise<Boolean> {
-        return new Promise(async (resolve) => {
-            let data = await this.readFileBuffer(zipFilePath);
-            this.zipResult = await this.zip.loadAsync(data);
-            resolve(true);
-        });
+    public static async loadZip(zipFilePath: string) {
+            const data = await this.readFileBuffer(zipFilePath);
+            this.zipResult = await this.zip.loadAsync(data).catch(error => {
+                throw error;
+            });
     }
 
     public static async parseSlideAttributes(fileName) {
-        let presentationSlide = await this.zipResult.file(fileName).async("text");
-        let parsedPresentationSlide = await xml2js(presentationSlide, {
+        const presentationSlide = await this.zipResult.file(fileName).async("text");
+        const parsedPresentationSlide = await xml2js(presentationSlide, {
             trim: true,
             preserveChildrenOrderForMixedContent: true
         });
@@ -26,7 +25,7 @@ export default class ZipHandler {
     }
 
     public static async getFileInZip(fileName) {
-        let file = await this.zipResult.file(fileName).async("base64");
+        const file = await this.zipResult.file(fileName).async("base64");
         return file;
     }
 

--- a/ts/parsers/elementparser.ts
+++ b/ts/parsers/elementparser.ts
@@ -21,6 +21,7 @@ class PowerpointElementParser {
                 return true;
             }
         }
+
         return false;
     }
 
@@ -68,10 +69,17 @@ class PowerpointElementParser {
         return { slideLayoutSpNode, slideMasterSpNode };
     }
 
-    public getPosition(slideLayoutTables, slideMasterTables) {
+    public getXfrmNodePosition(xfrmNode) {
         let position: PowerpointElement["elementPosition"] = null;
         let offset: PowerpointElement["elementOffsetPosition"] = null;
 
+        position = checkPath(xfrmNode, '["a:off"][0]["$"]') ? xfrmNode["a:off"][0]["$"] : position;
+        offset = checkPath(xfrmNode, '["a:off"][0]["$"]') ? xfrmNode["a:ext"][0]["$"] : offset;
+
+        return { position, offset };
+    }
+
+    public getPosition(slideLayoutTables, slideMasterTables) {
         const { slideLayoutSpNode, slideMasterSpNode } = this.getLayoutSpNodes(
             slideLayoutTables,
             slideMasterTables
@@ -82,28 +90,19 @@ class PowerpointElementParser {
         const slideLayoutXfrmNode = getValueAtPath(slideLayoutSpNode, xfrmNodePath);
         const slideMasterXfrmNode = getValueAtPath(slideMasterSpNode, xfrmNodePath);
 
-        if (slideXfrmNode && checkPath(slideXfrmNode, '["a:off"][0]["$"]')) {
-            position = slideXfrmNode["a:off"][0]["$"];
-            offset = slideXfrmNode["a:ext"][0]["$"];
-
-            return { position, offset };
+        if (slideXfrmNode) {
+            return this.getXfrmNodePosition(slideXfrmNode);
         }
 
-        if (slideLayoutXfrmNode && checkPath(slideLayoutXfrmNode, '["a:off"][0]["$"]')) {
-            position = slideLayoutXfrmNode["a:off"][0]["$"];
-            offset = slideLayoutXfrmNode["a:ext"][0]["$"];
-
-            return { position, offset };
+        if (slideLayoutXfrmNode) {
+            return this.getXfrmNodePosition(slideLayoutXfrmNode);
         }
 
-        if (slideMasterXfrmNode && checkPath(slideMasterXfrmNode, '["a:off"][0]["$"]')) {
-            position = slideMasterXfrmNode["a:off"][0]["$"];
-            offset = slideMasterXfrmNode["a:ext"][0]["$"];
-
-            return { position, offset };
+        if (slideMasterXfrmNode) {
+            return this.getXfrmNodePosition(slideMasterXfrmNode);
         }
 
-        return { position, offset };
+        return { position: null, offset: null };
     }
     public getProcessedElement(
         rawElement,

--- a/ts/parsers/elementparser.ts
+++ b/ts/parsers/elementparser.ts
@@ -24,6 +24,24 @@ class PowerpointElementParser {
         return false;
     }
 
+    public isPlaceholderListElement(slideLayoutTables): boolean {
+        if (checkPath(this.element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["idx"]')) {
+            const placeholderIdx = getValueAtPath(
+                this.element,
+                '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["idx"]'
+            );
+            let slideLayoutSpNode = undefined;
+            slideLayoutSpNode = slideLayoutTables["idxTable"][placeholderIdx];
+
+            return (
+                slideLayoutSpNode !== undefined &&
+                checkPath(slideLayoutSpNode, '["p:txBody"][0]["a:p"][0]["a:pPr"][0]["$"]["lvl"]')
+            );
+        }
+
+        return false;
+    }
+
     public getLayoutSpNodes(slideLayoutTables, slideMasterTables) {
         const idx =
             getAttributeByPath(this.element, ["p:nvSpPr", "p:nvPr", "p:ph"]) === undefined
@@ -135,6 +153,7 @@ class PowerpointElementParser {
 
             const paragraphInfo = getValueAtPath(this.element, '["p:txBody"][0]["a:p"]');
             const { position, offset } = this.getPosition(slideLayoutTables, slideMasterTables);
+            const isPlaceholderList = this.isPlaceholderListElement(slideLayoutTables);
 
             let pptElement: PowerpointElement = {
                 name: elementName,
@@ -149,7 +168,10 @@ class PowerpointElementParser {
                     cy: offset?.cy
                 },
                 table: !isEmpty(table) && !isEmpty(table.rows) ? table : null,
-                paragraph: ParagraphParser.extractParagraphElements(paragraphInfo),
+                paragraph: ParagraphParser.extractParagraphElements(
+                    paragraphInfo,
+                    isPlaceholderList
+                ),
                 shape: ShapeParser.extractShapeElements(this.element),
                 links: SlideRelationsParser.resolveShapeHyperlinks(this.element)
             };

--- a/ts/parsers/elementparser.ts
+++ b/ts/parsers/elementparser.ts
@@ -36,6 +36,43 @@ class PowerpointElementParser {
         return { slideLayoutSpNode, slideMasterSpNode };
     }
 
+    public getPosition(slideLayoutTables, slideMasterTables) {
+        let position: PowerpointElement["elementPosition"] = null;
+        let offset: PowerpointElement["elementOffsetPosition"] = null;
+
+        const { slideLayoutSpNode, slideMasterSpNode } = this.getLayoutSpNodes(
+            slideLayoutTables,
+            slideMasterTables
+        );
+
+        const xfrmNodePath = '["p:spPr"][0]["a:xfrm"][0]';
+        const slideXfrmNode = getValueAtPath(this.element, xfrmNodePath);
+        const slideLayoutXfrmNode = getValueAtPath(slideLayoutSpNode, xfrmNodePath);
+        const slideMasterXfrmNode = getValueAtPath(slideMasterSpNode, xfrmNodePath);
+
+        if (slideXfrmNode && checkPath(slideXfrmNode, '["a:off"][0]["$"]')) {
+            position = slideXfrmNode["a:off"][0]["$"];
+            offset = slideXfrmNode["a:ext"][0]["$"];
+
+            return { position, offset };
+        }
+
+        if (slideLayoutXfrmNode && checkPath(slideLayoutXfrmNode, '["a:off"][0]["$"]')) {
+            position = slideLayoutXfrmNode["a:off"][0]["$"];
+            offset = slideLayoutXfrmNode["a:ext"][0]["$"];
+
+            return { position, offset };
+        }
+
+        if (slideMasterXfrmNode && checkPath(slideMasterXfrmNode, '["a:off"][0]["$"]')) {
+            position = slideMasterXfrmNode["a:off"][0]["$"];
+            offset = slideMasterXfrmNode["a:ext"][0]["$"];
+
+            return { position, offset };
+        }
+
+        return { position, offset };
+    }
     public getProcessedElement(
         rawElement,
         slideLayoutTables,

--- a/ts/parsers/elementparser.ts
+++ b/ts/parsers/elementparser.ts
@@ -36,7 +36,8 @@ class PowerpointElementParser {
 
             return (
                 slideLayoutSpNode !== undefined &&
-                checkPath(slideLayoutSpNode, '["p:txBody"][0]["a:p"][0]["a:pPr"][0]["$"]["lvl"]')
+                checkPath(slideLayoutSpNode, '["p:txBody"][0]["a:p"][0]["a:pPr"][0]["$"]["lvl"]') &&
+                checkPath(slideLayoutSpNode, '["p:txBody"][0]["a:lstStyle"][0]["a:lvl1pPr"][0]["a:buNone"]') === false
             );
         }
 
@@ -104,6 +105,7 @@ class PowerpointElementParser {
 
         return { position: null, offset: null };
     }
+
     public getProcessedElement(
         rawElement,
         slideLayoutTables,

--- a/ts/parsers/elementparser.ts
+++ b/ts/parsers/elementparser.ts
@@ -1,23 +1,20 @@
-import { checkPath, getAttributeByPath, getValueAtPath } from "../helpers";
+import { checkPath, getValueAtPath } from "../helpers";
 import { PowerpointElement } from "airppt-models-plus/pptelement";
 import { GraphicFrameParser, ShapeParser, SlideRelationsParser, ParagraphParser } from "./";
 import { cleanupJson } from "../utils/common";
 import * as isEmpty from "lodash.isempty";
+import { SUPPORTED_PLACEHOLDERS } from "../utils/constants";
 
 /**
  * Entry point for all Parsers
  */
-const SUPPORTED_PLACEHOLDERS = ["body", "ctrTitle", "pic", "subTitle", "tbl", "title"];
 class PowerpointElementParser {
     private element;
 
     public isNonSupportedPlaceholder() {
         if (checkPath(this.element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]')) {
-            const type = getValueAtPath(
-                this.element,
-                '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]'
-            );
-            if (!SUPPORTED_PLACEHOLDERS.includes(type)) {
+            const type = getValueAtPath(this.element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]');
+            if (SUPPORTED_PLACEHOLDERS.includes(type) === false) {
                 return true;
             }
         }
@@ -27,12 +24,9 @@ class PowerpointElementParser {
 
     public isPlaceholderListElement(slideLayoutTables): boolean {
         if (checkPath(this.element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["idx"]')) {
-            const placeholderIdx = getValueAtPath(
-                this.element,
-                '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["idx"]'
-            );
-            let slideLayoutSpNode = undefined;
-            slideLayoutSpNode = slideLayoutTables["idxTable"][placeholderIdx];
+            const placeholderIdx = getValueAtPath(this.element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["idx"]');
+
+            const slideLayoutSpNode = slideLayoutTables["idxTable"][placeholderIdx];
 
             return (
                 slideLayoutSpNode !== undefined &&
@@ -45,14 +39,8 @@ class PowerpointElementParser {
     }
 
     public getLayoutSpNodes(slideLayoutTables, slideMasterTables) {
-        const idx =
-            getAttributeByPath(this.element, ["p:nvSpPr", "p:nvPr", "p:ph"]) === undefined
-                ? undefined
-                : getAttributeByPath(this.element, ["p:nvSpPr", "p:nvPr", "p:ph", "$", "idx"]);
-        const type =
-            getAttributeByPath(this.element, ["p:nvSpPr", "p:nvPr", "p:ph"]) === undefined
-                ? undefined
-                : getAttributeByPath(this.element, ["p:nvSpPr", "p:nvPr", "p:ph", "$", "type"]);
+        const idx = getValueAtPath(this.element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["idx"]');
+        const type = getValueAtPath(this.element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]');
 
         let slideLayoutSpNode = undefined;
         let slideMasterSpNode = undefined;
@@ -60,45 +48,42 @@ class PowerpointElementParser {
         if (type !== undefined) {
             slideLayoutSpNode = slideLayoutTables["typeTable"][type];
             slideMasterSpNode = slideMasterTables["typeTable"][type];
+
             return { slideLayoutSpNode, slideMasterSpNode };
         }
         if (idx !== undefined) {
             slideLayoutSpNode = slideLayoutTables["idxTable"][idx];
-            slideMasterSpNode = slideMasterSpNode["idxTable"][idx];
+            slideMasterSpNode = slideMasterTables["idxTable"][idx];
+
             return { slideLayoutSpNode, slideMasterSpNode };
         }
+
         return { slideLayoutSpNode, slideMasterSpNode };
     }
 
     public getXfrmNodePosition(xfrmNode) {
-        let position: PowerpointElement["elementPosition"] = null;
-        let offset: PowerpointElement["elementOffsetPosition"] = null;
-
-        position = checkPath(xfrmNode, '["a:off"][0]["$"]') ? xfrmNode["a:off"][0]["$"] : position;
-        offset = checkPath(xfrmNode, '["a:off"][0]["$"]') ? xfrmNode["a:ext"][0]["$"] : offset;
+        const position = getValueAtPath(xfrmNode, '["a:off"][0]["$"]');
+        const offset = getValueAtPath(xfrmNode, '["a:off"][0]["$"]');
 
         return { position, offset };
     }
 
     public getPosition(slideLayoutTables, slideMasterTables) {
-        const { slideLayoutSpNode, slideMasterSpNode } = this.getLayoutSpNodes(
-            slideLayoutTables,
-            slideMasterTables
-        );
+        const { slideLayoutSpNode, slideMasterSpNode } = this.getLayoutSpNodes(slideLayoutTables, slideMasterTables);
 
         const xfrmNodePath = '["p:spPr"][0]["a:xfrm"][0]';
         const slideXfrmNode = getValueAtPath(this.element, xfrmNodePath);
-        const slideLayoutXfrmNode = getValueAtPath(slideLayoutSpNode, xfrmNodePath);
-        const slideMasterXfrmNode = getValueAtPath(slideMasterSpNode, xfrmNodePath);
 
         if (slideXfrmNode) {
             return this.getXfrmNodePosition(slideXfrmNode);
         }
 
+        const slideLayoutXfrmNode = getValueAtPath(slideLayoutSpNode, xfrmNodePath);
         if (slideLayoutXfrmNode) {
             return this.getXfrmNodePosition(slideLayoutXfrmNode);
         }
 
+        const slideMasterXfrmNode = getValueAtPath(slideMasterSpNode, xfrmNodePath);
         if (slideMasterXfrmNode) {
             return this.getXfrmNodePosition(slideMasterXfrmNode);
         }
@@ -141,16 +126,12 @@ class PowerpointElementParser {
             else if (checkPath(this.element, '["a:graphic"][0]["a:graphicData"][0]["a:tbl"]')) {
                 elementName =
                     this.element["p:nvGraphicFramePr"][0]["p:cNvPr"][0]["$"]["title"] ||
-                    this.element["p:nvGraphicFramePr"][0]["p:cNvPr"][0]["$"]["name"].replace(
-                        /\s/g,
-                        ""
-                    );
+                    this.element["p:nvGraphicFramePr"][0]["p:cNvPr"][0]["$"]["name"].replace(/\s/g, "");
                 table = GraphicFrameParser.extractTableElements(this.element);
             }
 
             const elementPresetType =
-                getValueAtPath(this.element, '["p:spPr"][0]["a:prstGeom"][0]["$"]["prst"]') ||
-                "none";
+                getValueAtPath(this.element, '["p:spPr"][0]["a:prstGeom"][0]["$"]["prst"]') || "none";
 
             const paragraphInfo = getValueAtPath(this.element, '["p:txBody"][0]["a:p"]');
             const { position, offset } = this.getPosition(slideLayoutTables, slideMasterTables);
@@ -169,10 +150,7 @@ class PowerpointElementParser {
                     cy: offset?.cy
                 },
                 table: !isEmpty(table) && !isEmpty(table.rows) ? table : null,
-                paragraph: ParagraphParser.extractParagraphElements(
-                    paragraphInfo,
-                    isPlaceholderList
-                ),
+                paragraph: ParagraphParser.extractParagraphElements(paragraphInfo, isPlaceholderList),
                 shape: ShapeParser.extractShapeElements(this.element),
                 links: SlideRelationsParser.resolveShapeHyperlinks(this.element)
             };

--- a/ts/parsers/elementparser.ts
+++ b/ts/parsers/elementparser.ts
@@ -7,8 +7,22 @@ import * as isEmpty from "lodash.isempty";
 /**
  * Entry point for all Parsers
  */
+const SUPPORTED_PLACEHOLDERS = ["body", "ctrTitle", "pic", "subTitle", "tbl", "title"];
 class PowerpointElementParser {
     private element;
+
+    public isNonSupportedPlaceholder() {
+        if (checkPath(this.element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]')) {
+            const type = getValueAtPath(
+                this.element,
+                '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]'
+            );
+            if (!SUPPORTED_PLACEHOLDERS.includes(type)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public getLayoutSpNodes(slideLayoutTables, slideMasterTables) {
         const idx =
@@ -85,6 +99,10 @@ class PowerpointElementParser {
                 return null;
             }
             this.element = rawElement;
+
+            if (this.isNonSupportedPlaceholder()) {
+                return null;
+            }
 
             let elementName = "";
             let table = null;

--- a/ts/parsers/graphicFrameParser.ts
+++ b/ts/parsers/graphicFrameParser.ts
@@ -69,7 +69,7 @@ export default class GraphicFrameParser {
                 }
 
                 const paragraphInfo = getValueAtPath(col, '["a:txBody"][0]["a:p"]');
-                let parsedParagraph = ParagraphParser.extractParagraphElements(paragraphInfo);
+                let parsedParagraph = ParagraphParser.extractParagraphElements(paragraphInfo, false);
                 //edge case to handle the empty cell, without this check it will be sent as { paragraph: { content: [], ....}}
                 //and that is considered as line break in our renderer
                 if (parsedParagraph.length === 1 && isEmpty(parsedParagraph[0].content)) {

--- a/ts/parsers/graphicFrameParser.ts
+++ b/ts/parsers/graphicFrameParser.ts
@@ -4,6 +4,7 @@ import { getAttributeByPath, getValueAtPath } from "../helpers";
 import * as isEmpty from "lodash.isempty";
 import { TableDesign } from "airppt-models-plus/pptelement";
 import { ParagraphParser } from "./";
+import { SCHEMAS_URI } from "../utils/constants";
 
 export default class GraphicFrameParser {
     public static processGraphicFrameNodes = (graphicFrames) => {
@@ -13,12 +14,12 @@ export default class GraphicFrameParser {
             const graphicTypeUri = getAttributeByPath([frame], ["a:graphic", "a:graphicData", "$", "uri"]);
 
             switch (graphicTypeUri) {
-                case "http://schemas.openxmlformats.org/drawingml/2006/table":
+                case SCHEMAS_URI.TABLE:
                     result.push(frame);
                     break;
-                case "http://schemas.openxmlformats.org/drawingml/2006/chart":
+                case SCHEMAS_URI.CHART:
                     break;
-                case "http://schemas.openxmlformats.org/drawingml/2006/diagram":
+                case SCHEMAS_URI.DIAGRAM:
                     break;
                 default:
             }
@@ -42,7 +43,11 @@ export default class GraphicFrameParser {
     };
 
     public static extractTableElements = (frame) => {
-        const rawTable = getAttributeByPath([frame], ["a:graphic", "a:graphicData", "a:tbl"]);
+        const rawTable = getAttributeByPath([frame], ["a:graphic", "a:graphicData", "a:tbl"], []);
+
+        if (rawTable.length === 0) {
+            return null;
+        }
         const rawRows = rawTable[0]["a:tr"] ? rawTable[0]["a:tr"] : [];
 
         //TODO: column width mapping to be done here using rawTable[a:tblGrid]
@@ -58,7 +63,7 @@ export default class GraphicFrameParser {
             });
 
             cols = cols.map((col) => {
-                let meta = {};
+                const meta = {};
                 if (col["$"]) {
                     if (col["$"]["rowSpan"]) {
                         meta["rowSpan"] = col["$"]["rowSpan"];

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -51,16 +51,18 @@ export default class ParagraphParser {
         );
     }
 
-    public static isList(paragraph): boolean {
+    public static isList(paragraph, isListContent): boolean {
         return (
-            checkPath(paragraph, '["a:pPr"][0]["a:buAutoNum"]') ||
-            checkPath(paragraph, '["a:pPr"][0]["a:buChar"]')
+            (checkPath(paragraph, '["a:pPr"][0]["a:buAutoNum"]') ||
+                checkPath(paragraph, '["a:pPr"][0]["a:buChar"]') ||
+                isListContent) &&
+            checkPath(paragraph, '["a:pPr"][0]["a:buNone"]') === false
         );
     }
 
     public static getParagraph(paragraph): Paragraph {
         const textElements = paragraph["a:r"];
-        if(!textElements) {
+        if (!textElements) {
             return null;
         }
         let contents = textElements.map((txtElement) => {
@@ -123,7 +125,7 @@ export default class ParagraphParser {
         return list;
     }
 
-    public static extractParagraphElements(paragraphs: any[]): PowerpointElement["paragraph"] {
+    public static extractParagraphElements(paragraphs: any[], isListContent): PowerpointElement["paragraph"] {
         if (!paragraphs || paragraphs.length === 0) {
             return null;
         }
@@ -141,7 +143,7 @@ export default class ParagraphParser {
 
         for (const paragraphItem of paragraphs) {
             const parsedParagraph = this.getParagraph(paragraphItem);
-            if (this.isList(paragraphItem)) {
+            if (this.isList(paragraphItem, isListContent)) {
                 const listLevel = this.getListlevel(paragraphItem);
 
                 // if its the first of the list kind
@@ -189,7 +191,6 @@ export default class ParagraphParser {
                             listType: this.getListType(paragraphItem),
                             // listItems: [this.getParagraph(paragraphItem)]
                             listItems: parsedParagraph ? [parsedParagraph] : []
-
                         }
                     };
                     currentParagraph.list.listItems.push(newParagraph);
@@ -231,7 +232,6 @@ export default class ParagraphParser {
 
     /**a:rPr */
     public static determineTextProperties(textProperties): Content["textCharacterProperties"] {
-
         const defaultProperties: Content["textCharacterProperties"] = {
             size: 1200,
             fontAttributes: [],

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -44,10 +44,8 @@ export default class ParagraphParser {
 
     public static isTitle(element): boolean {
         return (
-            getValueAtPath(element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') ===
-                "ctrTitle" ||
-            getValueAtPath(element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') ===
-                "title"
+            getValueAtPath(element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') === "ctrTitle" ||
+            getValueAtPath(element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') === "title"
         );
     }
 
@@ -68,9 +66,7 @@ export default class ParagraphParser {
         let contents = textElements.map((txtElement) => {
             const content: Content = {
                 text: txtElement["a:t"] || "",
-                textCharacterProperties: this.determineTextProperties(
-                    getValueAtPath(txtElement, '["a:rPr"][0]')
-                )
+                textCharacterProperties: this.determineTextProperties(getValueAtPath(txtElement, '["a:rPr"][0]'))
             };
 
             const hyperlink = SlideRelationsParser.resolveParagraphHyperlink(txtElement);
@@ -245,12 +241,8 @@ export default class ParagraphParser {
 
         return {
             size: getValueAtPath(textProperties, '["$"].sz') || defaultProperties.size,
-            fontAttributes:
-                this.determineFontAttributes(textProperties["$"]) ||
-                defaultProperties.fontAttributes,
-            font:
-                getValueAtPath(textProperties, '["a:latin"][0]["$"]["typeface"]') ||
-                defaultProperties.font,
+            fontAttributes: this.determineFontAttributes(textProperties["$"]) || defaultProperties.fontAttributes,
+            font: getValueAtPath(textProperties, '["a:latin"][0]["$"]["typeface"]') || defaultProperties.font,
             fillColor: ColorParser.getTextColors(textProperties) || defaultProperties.fillColor
         };
     }
@@ -279,9 +271,7 @@ export default class ParagraphParser {
     }
 
     /**a:pPr */
-    public static determineParagraphProperties(
-        paragraphProperties
-    ): Paragraph["paragraphProperties"] {
+    public static determineParagraphProperties(paragraphProperties): Paragraph["paragraphProperties"] {
         if (!paragraphProperties) {
             return null;
         }

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -42,8 +42,10 @@ export default class ParagraphParser {
 
     public static isTitle(element): boolean {
         return (
-            getValueAtPath(element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') === "ctrTitle" ||
-            getValueAtPath(element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') === "title"
+            getValueAtPath(element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') ===
+                "ctrTitle" ||
+            getValueAtPath(element, '["p:nvSpPr"][0]["p:nvPr"][0]["p:ph"][0]["$"]["type"]') ===
+                "title"
         );
     }
 
@@ -206,6 +208,7 @@ export default class ParagraphParser {
                     allParagraphs.push(paragraph);
                     paragraph.list.listItems = [];
                 }
+                //normal paragraph content
                 allParagraphs.push(this.getParagraph(paragraphItem));
             }
         }
@@ -220,18 +223,28 @@ export default class ParagraphParser {
 
     /**a:rPr */
     public static determineTextProperties(textProperties): Content["textCharacterProperties"] {
-        if (!textProperties) {
-            return null;
-        }
 
-        const textPropertiesElement: Content["textCharacterProperties"] = {
-            size: getValueAtPath(textProperties, '["$"].sz') || 1200,
-            fontAttributes: this.determineFontAttributes(textProperties["$"]),
-            font: getValueAtPath(textProperties, '["a:latin"][0]["$"]["typeface"]') || "Helvetica",
-            fillColor: ColorParser.getTextColors(textProperties) || "000000"
+        const defaultProperties: Content["textCharacterProperties"] = {
+            size: 1200,
+            fontAttributes: [],
+            font: "Helvetica",
+            fillColor: "000000"
         };
 
-        return textPropertiesElement;
+        if (!textProperties) {
+            return defaultProperties;
+        }
+
+        return {
+            size: getValueAtPath(textProperties, '["$"].sz') || defaultProperties.size,
+            fontAttributes:
+                this.determineFontAttributes(textProperties["$"]) ||
+                defaultProperties.fontAttributes,
+            font:
+                getValueAtPath(textProperties, '["a:latin"][0]["$"]["typeface"]') ||
+                defaultProperties.font,
+            fillColor: ColorParser.getTextColors(textProperties) || defaultProperties.fillColor
+        };
     }
 
     /** Parse for italics, bold, underline & strike through*/

--- a/ts/parsers/pptGlobalsParser.ts
+++ b/ts/parsers/pptGlobalsParser.ts
@@ -1,9 +1,13 @@
 import { getAttributeByPath, ZipHandler } from "../helpers";
 export default class PptGlobalsParser {
     public static async getSlidesLength(pptFilePath: string) {
-        await ZipHandler.loadZip(pptFilePath);
-        const slideShowGlobals = await ZipHandler.parseSlideAttributes("ppt/presentation.xml");
+        try {
+            await ZipHandler.loadZip(pptFilePath);
+            const slideShowGlobals = await ZipHandler.parseSlideAttributes("ppt/presentation.xml");
 
-        return getAttributeByPath(slideShowGlobals, ["p:presentation", "p:sldIdLst", "p:sldId"], []).length;
+            return getAttributeByPath(slideShowGlobals, ["p:presentation", "p:sldIdLst", "p:sldId"], []).length;
+        } catch (error) {
+            throw error;
+        }
     }
 }

--- a/ts/parsers/pptGlobalsParser.ts
+++ b/ts/parsers/pptGlobalsParser.ts
@@ -1,10 +1,9 @@
-import { getAttributeByPath, ZipHandler} from "../helpers";
+import { getAttributeByPath, ZipHandler } from "../helpers";
 export default class PptGlobalsParser {
     public static async getSlidesLength(pptFilePath: string) {
-        //@todo: PROBLEM - Implement error handling
         await ZipHandler.loadZip(pptFilePath);
         const slideShowGlobals = await ZipHandler.parseSlideAttributes("ppt/presentation.xml");
 
-        return getAttributeByPath(slideShowGlobals, ["p:presentation", "p:sldIdLst", "p:sldId"]).length;
+        return getAttributeByPath(slideShowGlobals, ["p:presentation", "p:sldIdLst", "p:sldId"], []).length;
     }
 }

--- a/ts/parsers/slideParser.ts
+++ b/ts/parsers/slideParser.ts
@@ -3,12 +3,112 @@ import { getAttributeByPath, ZipHandler } from "../helpers";
 import { GraphicFrameParser, PowerpointElementParser } from "./";
 
 export default class SlideParser {
-    public static async getSlideElements(PPTElementParser: PowerpointElementParser, slideNumber): Promise<any[]> {
-        //Get all of Slide Shapes and Elements
-        const slideAttributes = await ZipHandler.parseSlideAttributes(format("ppt/slides/slide{0}.xml", slideNumber));
-        //Contains references to links,images and etc on a Slide
-        const slideRelations = await ZipHandler.parseSlideAttributes(format("ppt/slides/_rels/slide{0}.xml.rels", slideNumber));
+    public static getMasterLayout() {}
 
+    public static async getSlideLayout(slideRelations) {
+        // Read relationship filename of the slide (Get slideLayoutXX.xml)
+        // @sldFileName: ppt/slides/slide1.xml
+        // @resName: ppt/slides/_rels/slide1.xml.rels
+        const relationshipArray = slideRelations["Relationships"]["Relationship"];
+        let layoutFilename = "";
+        if (relationshipArray.constructor === Array) {
+            for (const relationship of relationshipArray) {
+                if (
+                    relationship["$"]["Type"] ===
+                    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout"
+                ) {
+                    layoutFilename = relationship["$"]["Target"].replace("../", "ppt/");
+                    break;
+                }
+            }
+        } else {
+            layoutFilename = relationshipArray["$"]["Target"].replace("../", "ppt/");
+        }
+        // Open slideLayoutXX.xml
+        const slideLayoutContent = await ZipHandler.parseSlideAttributes(layoutFilename);
+        return this.indexNodes(slideLayoutContent);
+    }
+
+    public static indexNodes(content) {
+        try {
+            const keys = Object.keys(content);
+            const spTreeNode = content[keys[0]]["p:cSld"][0]["p:spTree"][0];
+
+            const idTable = {};
+            const idxTable = {};
+            const typeTable = {};
+
+            for (const key in spTreeNode) {
+                if (key !== "p:sp") {
+                    continue;
+                }
+
+                var targetNode = spTreeNode[key];
+
+                if (targetNode.constructor === Array) {
+                    for (const node of targetNode) {
+                        const nvSpPrNode = node["p:nvSpPr"];
+                        const id = getAttributeByPath(nvSpPrNode[0], ["p:cNvPr", "$", "id"]);
+                        const idx = getAttributeByPath(nvSpPrNode[0], [
+                            "p:nvPr",
+                            "p:ph",
+                            "$",
+                            "idx"
+                        ]);
+                        const type = getAttributeByPath(nvSpPrNode[0], [
+                            "p:nvPr",
+                            "p:ph",
+                            "$",
+                            "type"
+                        ]);
+
+                        if (id !== undefined) {
+                            idTable[id] = node;
+                        }
+                        if (idx !== undefined) {
+                            idxTable[idx] = node;
+                        }
+                        if (type !== undefined) {
+                            typeTable[type] = node;
+                        }
+                    }
+                } else {
+                    const nvSpPrNode = targetNode["p:nvSpPr"];
+                    const id = getAttributeByPath(nvSpPrNode[0], ["p:cNvPr", "$", "id"]);
+                    const idx = getAttributeByPath(nvSpPrNode[0], ["p:nvPr", "p:ph", "$", "idx"]);
+                    const type = getAttributeByPath(nvSpPrNode[0], ["p:nvPr", "p:ph", "$", "type"]);
+
+                    if (id !== undefined) {
+                        idTable[id] = targetNode;
+                    }
+                    if (idx !== undefined) {
+                        idxTable[idx] = targetNode;
+                    }
+                    if (type !== undefined) {
+                        typeTable[type] = targetNode;
+                    }
+                }
+            }
+
+            return { idTable: idTable, idxTable: idxTable, typeTable: typeTable };
+        } catch (err) {
+            console.warn("Error indexing the layout nodes: ", err);
+        }
+    }
+
+    public static async getSlideElements(
+        PPTElementParser: PowerpointElementParser,
+        slideNumber
+    ): Promise<any[]> {
+        //Get all of Slide Shapes and Elements
+        const slideAttributes = await ZipHandler.parseSlideAttributes(
+            format("ppt/slides/slide{0}.xml", slideNumber)
+        );
+        //Contains references to links,images and etc on a Slide
+        const slideRelations = await ZipHandler.parseSlideAttributes(
+            format("ppt/slides/_rels/slide{0}.xml.rels", slideNumber)
+        );
+        const slideLayout = await this.getSlideLayout(slideRelations);
         const slideData = slideAttributes["p:sld"]["p:cSld"];
 
         //@todo: PROBLEM - Layering Order not Preserved, Shapes Render First, Need to fix

--- a/ts/parsers/slideParser.ts
+++ b/ts/parsers/slideParser.ts
@@ -69,9 +69,9 @@ export default class SlideParser {
                 if (Array.isArray(targetNode)) {
                     for (const node of targetNode) {
                         const nvSpPrNode = node["p:nvSpPr"];
-                        const id = getAttributeByPath(nvSpPrNode[0], ["p:cNvPr", "$", "id"]);
-                        const idx = getAttributeByPath(nvSpPrNode[0], ["p:nvPr", "p:ph", "$", "idx"]);
-                        const type = getAttributeByPath(nvSpPrNode[0], ["p:nvPr", "p:ph", "$", "type"]);
+                        const id = getAttributeByPath(nvSpPrNode, ["p:cNvPr", "$", "id"]);
+                        const idx = getAttributeByPath(nvSpPrNode, ["p:nvPr", "p:ph", "$", "idx"]);
+                        const type = getAttributeByPath(nvSpPrNode, ["p:nvPr", "p:ph", "$", "type"]);
 
                         if (id !== undefined) {
                             idTable[id] = node;
@@ -85,9 +85,9 @@ export default class SlideParser {
                     }
                 } else {
                     const nvSpPrNode = targetNode["p:nvSpPr"];
-                    const id = getAttributeByPath(nvSpPrNode[0], ["p:cNvPr", "$", "id"]);
-                    const idx = getAttributeByPath(nvSpPrNode[0], ["p:nvPr", "p:ph", "$", "idx"]);
-                    const type = getAttributeByPath(nvSpPrNode[0], ["p:nvPr", "p:ph", "$", "type"]);
+                    const id = getAttributeByPath(nvSpPrNode, ["p:cNvPr", "$", "id"]);
+                    const idx = getAttributeByPath(nvSpPrNode, ["p:nvPr", "p:ph", "$", "idx"]);
+                    const type = getAttributeByPath(nvSpPrNode, ["p:nvPr", "p:ph", "$", "type"]);
 
                     if (id !== undefined) {
                         idTable[id] = targetNode;

--- a/ts/utils/constants.ts
+++ b/ts/utils/constants.ts
@@ -1,0 +1,9 @@
+export const SCHEMAS_URI = {
+    TABLE: "http://schemas.openxmlformats.org/drawingml/2006/table",
+    CHART: "http://schemas.openxmlformats.org/drawingml/2006/chart",
+    DIAGRAM: "http://schemas.openxmlformats.org/drawingml/2006/diagram",
+    SLIDE_LAYOUT: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout",
+    SLIDE_MASTER: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster"
+};
+
+export const SUPPORTED_PLACEHOLDERS = ["body", "ctrTitle", "pic", "subTitle", "tbl", "title"];


### PR DESCRIPTION
### This PR includes
- Get slide and master layout information, create a mapping table for the nodes in the layouts, based on id, `idx` and `type`(Which is found on the placeholder type element, contained within `p:ph` tag). 
- Find the node of the powerpoint element in the layout tables. Referred as `spNode`
- Rewrite getting the positions logic to see if we don't find the element position, then we check from the slide layouts, if not then get from master layouts.
- Earlier the elements were removed from the resulting json if the positions were not found. Keep the placeholder elements even if the position is not found in layouts.
- exclude header, footers and slide-number type of placeholders, in-fact include only the placeholders that we support, which are `title, subtitles, body, pictures, tables and lists`
- Parse the placeholders lists.
- Remove extra paragraph contents added
- Remove empty list content.

#### Next Todos:
- Lists identification from the placeholders does not feel concrete, but the implementation right now cover all the cases that we have found. Throughout time we can see if there is any problems regarding this, which will result in making this identification better or to have more confidence in it. 
- Any other information that we might have and need from the placeholders, other than the position and list identification, may be required in the future, we will see it upon the use case or when the requirement rises.

_General knowledge on the placeholders and its types: http://officeopenxml.com/prSlide.php_
