### PR TITLE
fix: list types and heirarchy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.7",
+	"version": "1.1.8",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.1.7",
+			"version": "1.1.8",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.1.8",
+			"version": "1.1.9",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.7",
+	"version": "1.1.8",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -119,7 +119,7 @@ export default class ParagraphParser {
             }
         }
 
-        if (list.listItems.length !== 1 && list.listItems[list.listItems.length - 1].list) {
+        if (list.listItems.length > 1 && list.listItems[list.listItems.length - 1].list) {
             this.restructureList(list.listItems[list.listItems.length - 1].list);
         }
 

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -118,6 +118,11 @@ export default class ParagraphParser {
                 i--;
             }
         }
+
+        if (list.listItems.length !== 1 && list.listItems[list.listItems.length - 1].list) {
+            this.restructureList(list.listItems[list.listItems.length - 1].list);
+        }
+
         return list;
     }
 

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -217,6 +217,7 @@ export default class ParagraphParser {
                     paragraph.list = this.restructureList(paragraph.list);
                     allParagraphs.push(cloneDeep(paragraph));
                     paragraph.list.listItems = [];
+                    currentLevel = -1;
                 }
                 //normal paragraph content
                 parsedParagraph && allParagraphs.push(parsedParagraph);


### PR DESCRIPTION
This PR fixes: 
- If the same text box had different lists with different types, the type of the first list applied to the latter.
- In the multinested lists, after 2nd level and above, some sublists were not added as a child element to a previous list item, and stored as a separate list item. Which broke the tree like structure, and having the list item without content resulted in rendering the sublist under an empty list item child

 Previous PR for the lists: https://github.com/rabi92/airppt-parser/pull/5