### PR TITLE
Fix: empty children showing in the list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.9",
+	"version": "1.1.10",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.1.9",
+			"version": "1.1.10",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.7",
+	"version": "1.1.8",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.1.7",
+			"version": "1.1.8",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.1.8",
+			"version": "1.1.9",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.9",
+	"version": "1.1.10",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.7",
+	"version": "1.1.8",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -115,12 +115,8 @@ export default class ParagraphParser {
             if (list.listItems[i + 1].list) {
                 list.listItems[i]["list"] = list.listItems[i + 1].list;
                 list.listItems.splice(i + 1, 1);
-                i--;
+                this.restructureList(list.listItems[i].list);
             }
-        }
-
-        if (list.listItems.length > 1 && list.listItems[list.listItems.length - 1].list) {
-            this.restructureList(list.listItems[list.listItems.length - 1].list);
         }
 
         return list;

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -119,7 +119,7 @@ export default class ParagraphParser {
             }
         }
 
-        if (list.listItems.length !== 1 && list.listItems[list.listItems.length - 1].list) {
+        if (list.listItems.length > 1 && list.listItems[list.listItems.length - 1].list) {
             this.restructureList(list.listItems[list.listItems.length - 1].list);
         }
 

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -118,6 +118,11 @@ export default class ParagraphParser {
                 i--;
             }
         }
+
+        if (list.listItems.length !== 1 && list.listItems[list.listItems.length - 1].list) {
+            this.restructureList(list.listItems[list.listItems.length - 1].list);
+        }
+
         return list;
     }
 

--- a/ts/parsers/paragraphparser.ts
+++ b/ts/parsers/paragraphparser.ts
@@ -217,6 +217,7 @@ export default class ParagraphParser {
                     paragraph.list = this.restructureList(paragraph.list);
                     allParagraphs.push(cloneDeep(paragraph));
                     paragraph.list.listItems = [];
+                    currentLevel = -1;
                 }
                 //normal paragraph content
                 parsedParagraph && allParagraphs.push(parsedParagraph);


### PR DESCRIPTION
### This PR fixes: 
If there were multiple level of lists, in some levels, before showing list's children item, the list had an empty li item before it added the sublists items. 

Recursion was not running on the last list items. And never restructured the sublist to assign child parent relation.

This is already deployed to be tested by QA to check for any further issues. 
It's verified that this has been resolved, and working as expected.
_Note: parser version 1.1.10_