### PR TITLE
Parse grouped content (texts and images)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.11",
+	"version": "1.1.12",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.1.11",
+			"version": "1.1.12",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.7",
+	"version": "1.1.11",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "airppt-parser-plus",
-			"version": "1.1.7",
+			"version": "1.1.11",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^15.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.11",
+	"version": "1.1.12",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "airppt-parser-plus",
-	"version": "1.1.7",
+	"version": "1.1.11",
 	"description": "Parses Powerpoint (PPTX) to Standardized JSON Objects",
 	"main": "js/main.js",
 	"types": "js/main.d.ts",

--- a/ts/parsers/slideParser.ts
+++ b/ts/parsers/slideParser.ts
@@ -117,8 +117,8 @@ export default class SlideParser {
             groupedImages.push(...rootGroupNode["p:pic"]);
         }
         const subGroups = rootGroupNode["p:grpSp"];
-        if (subGroups && Array.isArray(subGroups) && isEmpty(subGroups) === false && groupCount <= GROUPS_LIMIT) {
-            subGroups.forEach(subGroup => {
+        if (subGroups && Array.isArray(subGroups) && groupCount <= GROUPS_LIMIT) {
+            subGroups.forEach((subGroup) => {
                 this.getGroupedNodes(subGroup, groupCount, groupedShapes, groupedImages);
             });
         }
@@ -140,13 +140,11 @@ export default class SlideParser {
         const graphicFrames = getAttributeByPath(slideData, ["p:spTree", "p:graphicFrame"], []);
 
         const groupedContent = getAttributeByPath(slideData, ["p:spTree", "p:grpSp"], []);
-        if (isEmpty(groupedContent) === false) {
-            groupedContent.forEach((group) => {
-                const { groupedShapes, groupedImages } = this.getGroupedNodes(group);
-                slideShapes.push(...groupedShapes);
-                slideImages.push(...groupedImages);
-            });
-        }
+        groupedContent.forEach((group) => {
+            const { groupedShapes, groupedImages } = this.getGroupedNodes(group);
+            slideShapes.push(...groupedShapes);
+            slideImages.push(...groupedImages);
+        });
 
         const slideTables = GraphicFrameParser.processGraphicFrameNodes(graphicFrames);
 

--- a/ts/parsers/slideParser.ts
+++ b/ts/parsers/slideParser.ts
@@ -1,7 +1,8 @@
 import * as format from "string-template";
-import { SCHEMAS_URI } from "../utils/constants";
+import { GROUPS_LIMIT, SCHEMAS_URI } from "../utils/constants";
 import { getAttributeByPath, ZipHandler } from "../helpers";
 import { GraphicFrameParser, PowerpointElementParser } from "./";
+import * as isEmpty from "lodash.isempty";
 
 export default class SlideParser {
     public static async getSlideLayout(slideRelations) {
@@ -107,6 +108,24 @@ export default class SlideParser {
         }
     }
 
+    public static getGroupedNodes(rootGroupNode, groupCount = 0, groupedShapes = [], groupedImages = []) {
+        groupCount++;
+        if (rootGroupNode["p:sp"]) {
+            groupedShapes.push(...rootGroupNode["p:sp"]);
+        }
+        if (rootGroupNode["p:pic"]) {
+            groupedImages.push(...rootGroupNode["p:pic"]);
+        }
+        const subGroups = rootGroupNode["p:grpSp"];
+        if (subGroups && Array.isArray(subGroups) && isEmpty(subGroups) === false && groupCount <= GROUPS_LIMIT) {
+            subGroups.forEach(subGroup => {
+                this.getGroupedNodes(subGroup, groupCount, groupedShapes, groupedImages);
+            });
+        }
+
+        return { groupedShapes, groupedImages };
+    }
+
     public static async getSlideElements(PPTElementParser: PowerpointElementParser, slideNumber): Promise<any[]> {
         //Get all of Slide Shapes and Elements
         const slideAttributes = await ZipHandler.parseSlideAttributes(format("ppt/slides/slide{0}.xml", slideNumber));
@@ -119,6 +138,16 @@ export default class SlideParser {
         const slideShapes = getAttributeByPath(slideData, ["p:spTree", "p:sp"], []);
         const slideImages = getAttributeByPath(slideData, ["p:spTree", "p:pic"], []);
         const graphicFrames = getAttributeByPath(slideData, ["p:spTree", "p:graphicFrame"], []);
+
+        const groupedContent = getAttributeByPath(slideData, ["p:spTree", "p:grpSp"], []);
+        if (isEmpty(groupedContent) === false) {
+            groupedContent.forEach((group) => {
+                const { groupedShapes, groupedImages } = this.getGroupedNodes(group);
+                slideShapes.push(...groupedShapes);
+                slideImages.push(...groupedImages);
+            });
+        }
+
         const slideTables = GraphicFrameParser.processGraphicFrameNodes(graphicFrames);
 
         const allSlideElements = [...slideShapes, ...slideImages, ...slideTables];

--- a/ts/utils/constants.ts
+++ b/ts/utils/constants.ts
@@ -7,3 +7,5 @@ export const SCHEMAS_URI = {
 };
 
 export const SUPPORTED_PLACEHOLDERS = ["body", "ctrTitle", "pic", "subTitle", "tbl", "title"];
+
+export const GROUPS_LIMIT = 20;


### PR DESCRIPTION
### This PR includes: 
Parsing of the content that are grouped together in the powerpoint. If the pictures and texts or the combination of them are grouped together.
_Note: It's not possible to group tables together with other elements as per our knowledge so far._ 